### PR TITLE
Fix Tutorial Showing Over Modal

### DIFF
--- a/app/application/controller.js
+++ b/app/application/controller.js
@@ -113,7 +113,7 @@ export default Ember.Controller.extend({
 	},
 
 	showTutorial: function () {
-		if (!this.get('isModalVisible')){
+		if (!this.get('modalOptions.isVisible')){
 			Ember.run.cancel(this.get('showTutorialTimer'));
 			this.showModal('ui/tutorial-intro', 'Tutorial');
 		}


### PR DESCRIPTION
This PR fixes the issue where the tutorial window would show over an already-opened modal because it was looking for the wrong modal visibility property.

@joshnesbitt, @nathanhebe can you confirm this is working for you?
