### PR TITLE
Starting PR Create Editable Story Blueprint

### DIFF
--- a/blueprints/story-editable/files/app/components/stories/complete/__name__/component.js
+++ b/blueprints/story-editable/files/app/components/stories/complete/__name__/component.js
@@ -1,0 +1,44 @@
+/* global Ember, hebeutils, _ */
+import DefaultStory from 'hebe-dash/components/stories/story-types/default-story/component';
+import EditableFields from 'hebe-dash/mixins/editable-fields';
+
+export default DefaultStory.extend(EditableFields, {
+    storyConfig: {
+        title: 'TITLE: <%= dasherizedModuleName %>',
+        subTitle: 'SUBTITLE: <%= dasherizedModuleName %>',
+        color: 'white',
+        width: '2',
+        height: '2',
+        scroll: true,
+    },
+    loaded: true,
+    editableFields: Ember.computed('storyModel', {
+        get() {
+            return [
+                {
+                    name:"title",
+                    type:"text",
+                    value:'',
+                    placeholder:'Enter your title'
+                },
+                {
+                    name: 'content',
+                    type:'markdown',
+                    value:'',
+                    placeholder:'Enter your content using markdown'
+                }
+            ];
+        }
+    }),
+    title: Ember.computed('storyModel.config.@each.value',{
+        get() {
+            return this.fetchEditableFieldValue('title');
+        }
+    }),
+    
+    content: Ember.computed('storyModel.config.@each.value',{
+        get() {
+            return this.fetchEditableFieldValue('content');
+        }
+    }),
+});

--- a/blueprints/story-editable/files/app/components/stories/complete/__name__/template.hbs
+++ b/blueprints/story-editable/files/app/components/stories/complete/__name__/template.hbs
@@ -1,0 +1,6 @@
+{{#stories/story-base}}
+    <h1>{{title}}</h1>
+    <div>
+        {{markdown-to-html markdown=content}}
+    </div>
+{{/stories/story-base}}

--- a/blueprints/story-editable/files/app/styles/components/stories/___name__.scss
+++ b/blueprints/story-editable/files/app/styles/components/stories/___name__.scss
@@ -1,0 +1,3 @@
+/*
+	Add story-specific styles here
+*/

--- a/blueprints/story-editable/files/tests/unit/components/stories/complete/__name__/component-test.js
+++ b/blueprints/story-editable/files/tests/unit/components/stories/complete/__name__/component-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('stories/complete/<%= dasherizedModuleName %>', {
+  // specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});

--- a/blueprints/story-editable/index.js
+++ b/blueprints/story-editable/index.js
@@ -1,0 +1,14 @@
+module.exports = {
+  description: ''
+
+  // locals: function(options) {
+  //   // Return custom template variables here.
+  //   return {
+  //     foo: options.entity.options.foo
+  //   };
+  // }
+
+  // afterInstall: function(options) {
+  //   // Perform extra work here.
+  // }
+};


### PR DESCRIPTION
- Extend `editable-fields` mixing
- provide a couple of example of
  - defining editable fields
  - observing editable field values with computed properties
  - using the properties in the template
