### PR TITLE
Fix SVG or Bitmap Logo Logic

### DIFF
--- a/app/components/dashboard-logo/component.js
+++ b/app/components/dashboard-logo/component.js
@@ -7,8 +7,8 @@ export default Ember.Component.extend({
 
     logoText: Ember.computed.alias('appSettings.solomonConfig.title'),
     
-    svgLogo: Ember.computed('appSettings.logoType', function() {
-        if (this.get('appSettings.logoType') == 'svg') {
+    svgLogo: Ember.computed('appSettings.solomonConfig.logoType', function() {
+        if (this.get('appSettings.solomonConfig.logoType') == 'svg') {
             return true;
         } else {
             return false;


### PR DESCRIPTION
The logic which looked for whether the app was setting an SVG or bitmap logo was looking for `appSettings.logoType` instead of `appSettings.solomonConfig.logoType` meaning the dashboard logo component always rendered out the bitmap block. This PR corrects this.
