### PR TITLE
Starting PR to add NHS canvas filtering by CCG or Provider

### DIFF
--- a/app/components/stories/complete/nhs-rtt/canvas-filter/template.hbs
+++ b/app/components/stories/complete/nhs-rtt/canvas-filter/template.hbs
@@ -16,7 +16,6 @@
 			{{ select-2
 				content=nhsFilter.regions
 				value=nhsFilter.selectedRegion
-
 				placeholder="Choose a region"
 			}}
     </p>
@@ -26,8 +25,6 @@
             {{ select-2
                 content=nhsFilter.ccgs
                 value=nhsFilter.selectedCCG
-                optionLabelPath="name"
-                optionValuePath="_id"
                 placeholder="Choose a CCG"
                 class="margin-bottom-no"
             }}
@@ -37,8 +34,6 @@
             {{ select-2
                 content=nhsFilter.providers
                 value=nhsFilter.selectedProvider
-                optionLabelPath="name"
-                optionValuePath="_id"
                 placeholder="Choose a Provider"
                 class="margin-bottom-no"
             }}

--- a/app/components/stories/complete/nhs-rtt/overall-perf-chart/component.js
+++ b/app/components/stories/complete/nhs-rtt/overall-perf-chart/component.js
@@ -13,7 +13,7 @@ export default DefaultStory.extend({
         width: 2,
         showLoading: true
     },
-    
+
     bars: [],
     barSelected: false,
     chosenBar: false,
@@ -23,28 +23,44 @@ export default DefaultStory.extend({
     of the PART_2
         % < 18
     */
-    
-    loadData: function(){
+
+    loadData: function () {
         var _this = this;
         var regionID = this.get('appSettings.canvasSettings.nhsFilter.selectedRegion.id');
-        var url = this.get('appSettings.hebeNodeAPI') +  '/nhsrtt/incompleteperformance/?regionid='+regionID+'&datekey=20150930&groupby=treatment';
+        var ccgID = this.get('appSettings.canvasSettings.nhsFilter.selectedCCG.id');
+        var providerID = this.get('appSettings.canvasSettings.nhsFilter.selectedProvider.id');
+        var month = this.get('appSettings.canvasSettings.nhsFilter.selectedMonth.id');
+        var url = this.get('appSettings.hebeNodeAPI') + '/nhsrtt/incompleteperformance/?datekey=' + month + '&groupby=treatment';
+        if (providerID) {
+            url += '&providerid=' + providerID;
+        } else if (ccgID) {
+            url += '&ccgid=' + ccgID;
+        } else {
+            url += '&regionid=' + regionID;
+        }
+        this.set('loaded',false);
         this.getData(url)
-            .then(function(data){
-                _this.set('data',data);
+            .then(function (data) {
+                _this.set('data', data);
             });
-    }.observes('appSettings.canvasSettings.nhsFilter.selectedRegion'),
-    
-    
+    }.observes(
+        'appSettings.canvasSettings.nhsFilter.selectedRegion',
+        'appSettings.canvasSettings.nhsFilter.selectedCCG',
+        'appSettings.canvasSettings.nhsFilter.selectedProvider',
+        'appSettings.canvasSettings.nhsFilter.selectedMonth'
+        ),
+
+
     onInsertElement: function () {
         this.loadData();
     }.on('didInsertElement'),
-    
-    addBarsToChart: function() {
+
+    addBarsToChart: function () {
         var _this = this;
         var data = this.get('data');
         var locations = [];
         // var avg = 0;
-        for(var i = 0; i < data.length; i ++){
+        for (var i = 0; i < data.length; i++) {
             var obj = Ember.Object.create({
                 location: data[i].name,
                 percentage: ((data[i].gt_00_to_18_weeks_sum / data[i].total_all_sum) * 100).toPrecisionDigits(1)
@@ -58,8 +74,8 @@ export default DefaultStory.extend({
             "national": 92,
             // "avg": avg
         });
-        
-        locations = _.sortBy(locations,function(obj) {
+
+        locations = _.sortBy(locations, function (obj) {
             return obj.percentage;
         });
         
@@ -114,15 +130,15 @@ export default DefaultStory.extend({
         
         _this.set('bars', locations);
         _this.arrangeBars();
-        
+
         setTimeout(function () {
             _this.set('loaded', true);
         });
     }.observes('data'),
-    
-    arrangeBars: function() {
+
+    arrangeBars: function () {
         var _this = this;
-        
+
         var numBars = _this.get('bars.length'), // $('[spc-opc_bars]').find('[spc-opc_bar]').length,
             chartHeight = _this.$('[spc-opc_bars]').outerHeight(),
             spacing = (chartHeight / numBars) / 2;
@@ -131,11 +147,11 @@ export default DefaultStory.extend({
         // console.log('Chart height: ' + chartHeight);
         // console.log('Spacing: ' + spacing);
             
-        _this.get('bars').forEach(function(bar) {
+        _this.get('bars').forEach(function (bar) {
             bar.setProperties({
-                'height':spacing,
-                'margin-bottom':spacing,
-                'spacing':spacing + 'px'
+                'height': spacing,
+                'margin-bottom': spacing,
+                'spacing': spacing + 'px'
             });
         });
         
@@ -145,15 +161,15 @@ export default DefaultStory.extend({
         //         .css('margin-bottom', spacing);
         // });
     },
-    
+
     actions: {
-        setSelectedBar: function(bar) {
+        setSelectedBar: function (bar) {
             // alert(bar);
-            if(!Ember.isEmpty(this.get('selectedBar'))) {
-                this.set('selectedBar.isSelected',false);
+            if (!Ember.isEmpty(this.get('selectedBar'))) {
+                this.set('selectedBar.isSelected', false);
             }
-            bar.set('isSelected',true);
-            this.set('selectedBar',bar);
+            bar.set('isSelected', true);
+            this.set('selectedBar', bar);
         }
     }
 });

--- a/app/components/stories/complete/nhs-rtt/rtt-data-table/component.js
+++ b/app/components/stories/complete/nhs-rtt/rtt-data-table/component.js
@@ -24,13 +24,28 @@ export default DefaultStory.extend({
 
     onDidInsertElement: function () {
         var _this = this;
-        var regionID = this.get('nhsFilter.selectedRegion._id');
+        var regionID = this.get('nhsFilter.selectedRegion.id');
+        var ccgID = this.get('nhsFilter.selectedCCG.id');
+        var providerID = this.get('nhsFilter.selectedProvider.id');
+        var url = this.get('appSettings.hebeNodeAPI') + '/nhsrtt/monthly/';
+        // regions/' + regionID + '';  // do get by parts (admitted etc) add ?parts=true
+        if (providerID) {
+            url += 'provider/' + providerID;
+        } else if (ccgID) {
+            url += 'ccgs/' + ccgID;
+        } else {
+            url += 'regions/' + regionID;
+        }
         var headings = this.get('headings');
-        this.getData(this.get('appSettings.hebeNodeAPI') + '/nhsrtt/monthly/regions/' + regionID + '') // do get by parts (admitted etc) add ?parts=true
+        this.getData(url)
             .then(function (data) {
-                if(data.length > 0 && data[0].months) {
+                if(data.months && data.months.length > 0) {
+                    data = data.months;   
+                } else if (data.length > 0 && data[0].months) {
                     data = data[0].months;
-                    data = _.sortBy(data,function(obj){
+                }
+                if(data) {
+                    data = _.sortBy(data, function (obj) {
                         return obj._id.date;
                     });
                     data.reverse();
@@ -39,20 +54,24 @@ export default DefaultStory.extend({
                         for (var i = 0; i < headings.length; i++) {
                             var prop = headings[i].property;
                             var val = obj[prop];
-                            if(prop === "_id") {
-                                val = moment(obj._id.date,"YYYYMMDD").format("MM YYYY");
+                            if (prop === "_id") {
+                                val = moment(obj._id.date, "YYYYMMDD").format("MM YYYY");
                             }
                             row.push(val);
                         }
                         return row;
                     });
                     _this.set('rows', rows);
-                    setTimeout(function() {
+                    setTimeout(function () {
                         _this.set('loaded', true);
                     });
                 }
             });
-    }.on('didInsertElement').observes('nhsFilter.selectedRegion')
+    }.on('didInsertElement').observes(
+        'nhsFilter.selectedRegion',
+        'nhsFilter.selectedProvider',
+        'nhsFilter.selectedCCG'
+        )
 
 
 });

--- a/app/utils/app-settings.js
+++ b/app/utils/app-settings.js
@@ -205,8 +205,12 @@ export default Ember.Object.extend({
         });
     },
     onNHSSelectedRegionChange: function(){
-        this.set('canvasSettings.nhsFilter.providers', this.get('canvasSettings.nhsFilter.selectedRegion.providers'));
-        this.set('canvasSettings.nhsFilter.ccgs', this.get('canvasSettings.nhsFilter.selectedRegion.ccgs'));
+        this.setProperties({
+            'canvasSettings.nhsFilter.providers': this.get('canvasSettings.nhsFilter.selectedRegion.providers'),
+            'canvasSettings.nhsFilter.ccgs': this.get('canvasSettings.nhsFilter.selectedRegion.ccgs'),
+            'canvasSettings.nhsFilter.selectedProvider': null,
+            'canvasSettings.nhsFilter.selectedCCG': null
+        });
     }.observes('canvasSettings.nhsFilter.selectedRegion'), 
 
 /////////////////////////////////////////////////////////////////

--- a/app/utils/app-settings.js
+++ b/app/utils/app-settings.js
@@ -205,13 +205,39 @@ export default Ember.Object.extend({
         });
     },
     onNHSSelectedRegionChange: function(){
+        var providers = this.get('canvasSettings.nhsFilter.selectedRegion.providers');
+        var ccgs = this.get('canvasSettings.nhsFilter.selectedRegion.ccgs');
+        if (!Ember.isEmpty(providers)) {
+            providers.forEach(function (provider) {
+                provider.id = provider._id;
+                provider.text = provider.name;
+            });
+        }
+        if (!Ember.isEmpty(ccgs)) {
+            ccgs.forEach(function (ccg) {
+                ccg.id = ccg._id;
+                ccg.text = ccg.name;
+            });
+        }
+        
         this.setProperties({
-            'canvasSettings.nhsFilter.providers': this.get('canvasSettings.nhsFilter.selectedRegion.providers'),
-            'canvasSettings.nhsFilter.ccgs': this.get('canvasSettings.nhsFilter.selectedRegion.ccgs'),
+            'canvasSettings.nhsFilter.providers': providers,
+            'canvasSettings.nhsFilter.ccgs': ccgs,
             'canvasSettings.nhsFilter.selectedProvider': null,
             'canvasSettings.nhsFilter.selectedCCG': null
         });
     }.observes('canvasSettings.nhsFilter.selectedRegion'), 
+    
+    onNHSSelectedProviderChange: function(){
+        if(this.get('canvasSettings.nhsFilter.selectedProvider')) {
+            this.set('canvasSettings.nhsFilter.selectedCCG',null);
+        }
+    }.observes('canvasSettings.nhsFilter.selectedProvider'), 
+    onNHSSelectedCCGChange: function(){
+        if(this.get('canvasSettings.nhsFilter.selectedCCG')) {
+            this.set('canvasSettings.nhsFilter.selectedProvider',null);
+        }
+    }.observes('canvasSettings.nhsFilter.selectedCCG'), 
 
 /////////////////////////////////////////////////////////////////
 // End NHS Canvas Filtering


### PR DESCRIPTION
Currently a user can filter an NHS RTT canvas by Region & Month
- [ ] A user can select a CCG in the canvas filter
- [ ] A user can select a Provider in the canvas filter
- [ ] Stories observing selectedRegion should also update when a CCG or provider is selected
  - [ ] display a message when a story's data can be filtered by region but not CCG/Provider
