### PR TITLE
Update Story Header Logic

### DIFF
--- a/app/components/stories/story-base/component.js
+++ b/app/components/stories/story-base/component.js
@@ -89,10 +89,29 @@ export default Ember.Component.extend({
 
     // Tell the story component if there is a header.
     hasHeader: Ember.computed('storyConfig.headerImage', 'storyConfig.title', function () {
-        if (this.get('storyConfig.headerImage') != '' || this.get('storyConfig.title') != '') {
-            return 'has-header';
+        var headerImage = this.get('storyConfig.headerImage'),
+            title = this.get('storyConfig.title'),
+            subTitle = this.get('storyConfig.subTitle');
+        
+        if (headerImage != '' || (title != '' && subTitle != '')) {
+            return 'has-full-header';
+        } else if (title != '' && subTitle == '') {
+            return 'has-half-header';
         } else {
-            return 'no-header';
+            return 'has-no-header';
+        }
+    }),
+    
+    // Tell the story header how tall it should be.
+    headerSize: Ember.computed('storyConfig.headerImage', 'storyConfig.title', function () {
+        var headerImage = this.get('storyConfig.headerImage'),
+            title = this.get('storyConfig.title'),
+            subTitle = this.get('storyConfig.subTitle');
+        
+        if (headerImage != '' || (title != '' && subTitle != '')) {
+            return 'full';
+        } else if (title != '' && subTitle == '') {
+            return 'half';
         }
     }),
 

--- a/app/components/stories/story-base/component.js
+++ b/app/components/stories/story-base/component.js
@@ -40,7 +40,8 @@ export default Ember.Component.extend({
         slider: false,
         scroll: true,
         customProperties: '',
-        showLoading: false
+        showLoading: false,
+        showHeaderBorder: true
     },
 
     attributeBindings: ['data-ss-colspan', 'data-id', 'data-canvas-order-index', 'cpn-story'],
@@ -59,6 +60,7 @@ export default Ember.Component.extend({
         'target.storyConfig.scroll',
         'target.storyConfig.customProperties',
         'target.storyConfig.showLoading',
+        'target.storyConfig.showHeaderBorder',
         function () {
             var targetConfig = Ember.Object.create(this.get('target.storyConfig'));
             var defaultConfig = Ember.Object.create(this.get('defaultConfig'));
@@ -126,10 +128,10 @@ export default Ember.Component.extend({
 
     // We only want a dividing line under the header on larger stories.
     hasHeaderDivide: Ember.computed('storyConfig.height', function () {
-        if (this.get('storyConfig.height') == 1) {
-            return '';
+        if (this.get('storyConfig.height') == 1 || this.get('storyConfig.showHeaderBorder') == false) {
+            return false;
         } else {
-            return 'cpn-divide="bottom solid ' + this.get('lineShade') + '"';
+            return true;
         }
     }),
 

--- a/app/components/stories/story-base/template.hbs
+++ b/app/components/stories/story-base/template.hbs
@@ -46,17 +46,6 @@
                 {{/if}}
             {{/if}}
             
-            {{!-- {{#if storyConfig.headerImage}}
-                <header cpn-story_header="{{headerSize}}" {{hasHeaderDivide}}>
-                    <img src="{{storyConfig.headerImage}}" height="24">
-                </header>
-            {{else if storyConfig.title}}
-                <header cpn-story_header="{{headerSize}}" {{hasHeaderDivide}}>
-                    <h2 cpn-story_title>{{storyConfig.title}}</h2>
-                    <h3 cpn-story_desc>{{storyConfig.subTitle}}</h3>
-                </header>
-            {{/if}} --}}
-            
             {{#if hasHeaderDivide}}
             <main cpn-story_body="{{hasHeader}} {{usableHeight}} {{hasSlider}} {{canScroll}}">
                 {{yield}}

--- a/app/components/stories/story-base/template.hbs
+++ b/app/components/stories/story-base/template.hbs
@@ -23,6 +23,30 @@
         <section cpn-story_content="front {{usableHeight}} {{hasHeader}} {{hasFooter}}">
             
             {{#if storyConfig.headerImage}}
+                {{#if hasHeaderDivide}}
+                <header cpn-story_header="{{headerSize}}" cpn-divide="solid bottom {{lineShade}}">
+                    <img src="{{storyConfig.headerImage}}" height="24">
+                </header>
+                {{else}}
+                <header cpn-story_header="{{headerSize}}">
+                    <img src="{{storyConfig.headerImage}}" height="24">
+                </header>
+                {{/if}}
+            {{else if storyConfig.title}}
+                {{#if hasHeaderDivide}}
+                <header cpn-story_header="{{headerSize}}" cpn-divide="solid bottom {{lineShade}}">
+                    <h2 cpn-story_title>{{storyConfig.title}}</h2>
+                    <h3 cpn-story_desc>{{storyConfig.subTitle}}</h3>
+                </header>
+                {{else}}
+                <header cpn-story_header="{{headerSize}}">
+                    <h2 cpn-story_title>{{storyConfig.title}}</h2>
+                    <h3 cpn-story_desc>{{storyConfig.subTitle}}</h3>
+                </header>
+                {{/if}}
+            {{/if}}
+            
+            {{!-- {{#if storyConfig.headerImage}}
                 <header cpn-story_header="{{headerSize}}" {{hasHeaderDivide}}>
                     <img src="{{storyConfig.headerImage}}" height="24">
                 </header>
@@ -31,11 +55,17 @@
                     <h2 cpn-story_title>{{storyConfig.title}}</h2>
                     <h3 cpn-story_desc>{{storyConfig.subTitle}}</h3>
                 </header>
-            {{/if}}
+            {{/if}} --}}
             
+            {{#if hasHeaderDivide}}
             <main cpn-story_body="{{hasHeader}} {{usableHeight}} {{hasSlider}} {{canScroll}}">
                 {{yield}}
             </main>
+            {{else}}
+            <main cpn-story_body="{{hasHeader}} {{usableHeight}} {{hasSlider}} {{canScroll}} no-header-border">
+                {{yield}}
+            </main>
+            {{/if}}
             
             {{#unless storyConfig.viewOnly}}
                 <footer cpn-story_footer cpn-clearfix cpn-divide="top solid {{lineShade}}">

--- a/app/components/stories/story-base/template.hbs
+++ b/app/components/stories/story-base/template.hbs
@@ -23,11 +23,11 @@
         <section cpn-story_content="front {{usableHeight}} {{hasHeader}} {{hasFooter}}">
             
             {{#if storyConfig.headerImage}}
-                <header cpn-story_header {{hasHeaderDivide}}>
+                <header cpn-story_header="{{headerSize}}" {{hasHeaderDivide}}>
                     <img src="{{storyConfig.headerImage}}" height="24">
                 </header>
             {{else if storyConfig.title}}
-                <header cpn-story_header {{hasHeaderDivide}}>
+                <header cpn-story_header="{{headerSize}}" {{hasHeaderDivide}}>
                     <h2 cpn-story_title>{{storyConfig.title}}</h2>
                     <h3 cpn-story_desc>{{storyConfig.subTitle}}</h3>
                 </header>

--- a/app/styles/cpn/_cpn-story.scss
+++ b/app/styles/cpn/_cpn-story.scss
@@ -312,6 +312,7 @@
                 [cpn-story_body~="has-half-header"][cpn-story_body~="no-slider"]:not([cpn-story_body~="height-1"]) {
                     padding-top: rem($spacing-base);
                     
+                    &[cpn-story_body~="no-header-border"],
                     [solomon-app~="yorkshire-water"] & {
                         padding-top: 0;
                     }
@@ -356,6 +357,10 @@
                                     overflow-y: auto;
                                     -webkit-overflow-scrolling: touch;
                                     -ms-overflow-style: -ms-autohiding-scrollbar;
+                                }
+                                
+                                [cpn-story_body~="no-header-border"] & {
+                                    padding-top: 0;
                                 }
                             }
                             

--- a/app/styles/cpn/_cpn-story.scss
+++ b/app/styles/cpn/_cpn-story.scss
@@ -214,8 +214,12 @@
                 position: relative;
             }
             
-            [cpn-story_content~="has-header"] {
+            [cpn-story_content~="has-full-header"] {
                 padding-top: rem(36px);
+            }
+            
+            [cpn-story_content~="has-half-header"] {
+                padding-top: rem(23px);
             }
             
             [cpn-story_content~="has-footer"] {
@@ -254,7 +258,6 @@
             }
             
                 [cpn-story_header] {
-                    height: rem(36px);
                     width: 100%;
                     position: absolute;
                     top: 0;
@@ -264,6 +267,14 @@
                         border-bottom: 0;
                         margin-bottom: 0;
                     }
+                }
+                
+                [cpn-story_header~="full"] {
+                    height: rem(36px);
+                }
+                
+                [cpn-story_header~="half"] {
+                    height: rem(23px);
                 }
             
                     [cpn-story_title] {
@@ -297,7 +308,8 @@
                     margin-left: rem(-$spacing-base);
                 }
                 
-                [cpn-story_body~="has-header"][cpn-story_body~="no-slider"]:not([cpn-story_body~="height-1"]) {
+                [cpn-story_body~="has-full-header"][cpn-story_body~="no-slider"]:not([cpn-story_body~="height-1"]),
+                [cpn-story_body~="has-half-header"][cpn-story_body~="no-slider"]:not([cpn-story_body~="height-1"]) {
                     padding-top: rem($spacing-base);
                     
                     [solomon-app~="yorkshire-water"] & {

--- a/config/environment.js
+++ b/config/environment.js
@@ -79,7 +79,6 @@ module.exports = function (environment) {
     // ENV.APP.hebeNodeAPI = 'http://localhost:3000';
     // ENV.APP.hebeNodeAPI = 'http://hebenodeapi-cached.azurewebsites.net';
     // ENV.APP.mockSolomonHostname = 'leeds.preview.mysolomon.co.uk'; // lets you simulate a particular site e.g. 'leeds.preview.mysolomon.co.uk' core etc
-    ENV.APP.mockSolomonHostname = 'nhsrtt.preview.mysolomon.co.uk'
 }
 
   if (environment === 'test') {


### PR DESCRIPTION
Currently, if you want to output just the story title without a subtitle, this leaves a gap where the sub title would have been. So, to get around this, we've been setting a blank title and adding a 'pseudo title' into the story body. This PR updates the logic which constructs and styles the story to give more flexibility when adding story titles.
