### PR TITLE
Fix Textarea Appearance

### DIFF
--- a/app/styles/cpn/_cpn-input.scss
+++ b/app/styles/cpn/_cpn-input.scss
@@ -3,10 +3,12 @@ $input-border-width: 2px;
 
 // Text fields (inc. password, email textarea etc.)
 [cpn-input~="text"],
+[cpn-input~="textarea"],
 input[type="text"],
 input[type="email"],
 input[type="password"],
-input[type="number"] {
+input[type="number"],
+textarea {
     display: block;
     width: 100%;
     max-width: 100%;


### PR DESCRIPTION
Textareas are missing base styles because certain selectors are missing. This PR addresses that.
