### PR TITLE
Embed RAG Tile Trend Graphic

### DIFF
--- a/app/components/stories/complete/base-rag-tile/component.js
+++ b/app/components/stories/complete/base-rag-tile/component.js
@@ -36,5 +36,9 @@ export default DefaultStory.extend({
         } else {
             this.set('storyConfig.color','amber');
         }
-    }.observes('rating')
+    }.observes('rating'),
+    
+    onTrend: function() {
+        Ember.run.scheduleOnce('afterRender', this, grunticon.embedSVG);
+    }.observes('trend')
 });


### PR DESCRIPTION
Currently, when you load a RAG tile, the trend graphic isn't embedded into the story. We'll address that in this PR by running Grunt SVG when 'trend' updates.
