### PR TITLE
Fix missing attribute on Canvas element

### DIFF
--- a/app/components/canvas-element/template.hbs
+++ b/app/components/canvas-element/template.hbs
@@ -4,7 +4,7 @@
     {{/if}}
 </h1>
 
-<div class="js-canvas canvas">
+<div class="js-canvas canvas" cpn-canvas>
     <a href="javascript:;" class="js-canvas-overlay canvas__overlay"></a>
     <div class="js-stories canvas__inner">
     


### PR DESCRIPTION
When the Manipulation Panel was built, a new attribute was added to the Canvas element: `cpn-canvas`. This attribute is required by the Manipulation Panel code. It appears to have been lost/removed in subsequent branching and merging. This PR puts that attribute back on.
