### PR TITLE
Add initializer for adding custom attributes to components

### DIFF
--- a/app/initializers/add-custom-attributes.js
+++ b/app/initializers/add-custom-attributes.js
@@ -1,0 +1,11 @@
+export function initialize(/* container, application */) {
+  // application.inject('route', 'foo', 'service:foo');
+  Ember.LinkComponent.reopen({
+    attributeBindings: ['cpn-button']
+  });
+}
+
+export default {
+  name: 'add-custom-attributes',
+  initialize: initialize
+};

--- a/tests/unit/initializers/add-custom-attributes-test.js
+++ b/tests/unit/initializers/add-custom-attributes-test.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+import { initialize } from '../../../initializers/add-custom-attributes';
+import { module, test } from 'qunit';
+
+var registry, application;
+
+module('Unit | Initializer | add custom attributes', {
+  beforeEach: function() {
+    Ember.run(function() {
+      application = Ember.Application.create();
+      registry = application.registry;
+      application.deferReadiness();
+    });
+  }
+});
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  initialize(registry, application);
+
+  // you would normally confirm the results of the initializer here
+  assert.ok(true);
+});


### PR DESCRIPTION
There have been quite a few instances where there has been a need to add custom attributes to components not currently not currently whitelisted by Ember. So we'll add a new initializer into which we can reopen components to add attributes we need.
