### PR TITLE
Starting PR to allow local development overriding of Solomon API client app

### DIFF
--- a/app/application/adapter.js
+++ b/app/application/adapter.js
@@ -16,6 +16,10 @@ export default DS.JSONAPIAdapter.extend({
         if(typeof token === 'string'){
           headers['Authorization'] = 'Bearer ' + token;
         }
+        
+        if(!Ember.isEmpty(config.APP.solomonClientOverride)) {
+          headers['Solomon-Client-Override'] = config.APP.solomonClientOverride;
+        }
 
         return headers;
     }).property('session.secure.jwt')

--- a/config/environment.js
+++ b/config/environment.js
@@ -33,6 +33,7 @@ module.exports = function config(environment) {
     // LOCAL
       hebeNodeAPI: 'http://hebenodeapi-testing.azurewebsites.net/',
       solomonAPIURL: 'http://solomonapi-testing.azurewebsites.net',
+      // solomonAPIURL: 'http://localhost:3000',
 
     // PREVIEW
     //   hebeNodeAPI: 'http://hebenodeapi-testing.azurewebsites.net/',
@@ -64,16 +65,16 @@ module.exports = function config(environment) {
   // };
   
   // PRODUCTION
-  ENV['auth0-ember-simple-auth'] = {
-    clientID: 'PD0dK4nnC2JDWDbkMxHVEPIRtYJV39zI',
-    domain: 'solomon.eu.auth0.com',
-  };
+  // ENV['auth0-ember-simple-auth'] = {
+  //   clientID: 'PD0dK4nnC2JDWDbkMxHVEPIRtYJV39zI',
+  //   domain: 'solomon.eu.auth0.com',
+  // };
 
     // BID
-  // ENV['auth0-ember-simple-auth'] = {
-  //   clientID: 'hM1EVxNIpGwhZ8nxVL010SIK1yIOhaPD',
-  //   domain: 'solomonbid.eu.auth0.com',
-  // };
+  ENV['auth0-ember-simple-auth'] = {
+    clientID: 'hM1EVxNIpGwhZ8nxVL010SIK1yIOhaPD',
+    domain: 'solomonbid.eu.auth0.com',
+  };
 
 //    NHS
 //  ENV['auth0-ember-simple-auth'] = {
@@ -103,7 +104,8 @@ module.exports = function config(environment) {
         // ENV.APP.hebeNodeAPI = 'http://hebenodeapi-cached.azurewebsites.net';
         // lets you simulate a particular site e.g. 'leeds.preview.mysolomon.co.uk' core etc
         // ENV.APP.mockSolomonHostname = 'leeds.preview.mysolomon.co.uk';
-        ENV.APP.mockSolomonHostname = 'bid.preview.mysolomon.co.uk'
+        ENV.APP.mockSolomonHostname = 'bid.preview.mysolomon.co.uk';
+        ENV.APP.solomonClientOverride = "solomon_bid_leeds";
     }
 
   if (environment === 'test') {


### PR DESCRIPTION
In combination with changes in the Solomon API we want to be able to force serving of a particular solomon client e.g. instead of local_dev, impersonate york or leeds
