### PR TITLE
Fix cpn-text utility attribute

### DIFF
--- a/app/styles/cpn/_cpn-text.scss
+++ b/app/styles/cpn/_cpn-text.scss
@@ -8,11 +8,11 @@
 }
 
 [cpn-text~="left"] {
-    text-align: center;
+    text-align: left;
 }
 
 [cpn-text~="right"] {
-    text-align: center;
+    text-align: right;
 }
 
 // Decoration


### PR DESCRIPTION
The options in this utility attribute to align text left or right are actually aligning text to centre. Correcting in this PR.
