### PR TITLE
Realign form labels

### DIFF
--- a/app/styles/cpn/_cpn-label.scss
+++ b/app/styles/cpn/_cpn-label.scss
@@ -2,6 +2,5 @@
     display: inline-block;
     font-size: rem(12px);
     font-weight: 500;
-    margin-left: rem($spacing-base * 1.5);
     margin-bottom: rem($spacing-base / 2);
 }


### PR DESCRIPTION
Form labels need to be realigned to the edge of the input box, rather than the content inside.
