### PR TITLE
Fix issue with dotdotdot bower package

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -52,6 +52,6 @@ app.import('vendor/embedsvg/grunticon.inline.js');
 app.import('vendor/modernizr-custom.min.js');
 app.import(app.bowerDirectory + '/jQuery.XDomainRequest/jquery.xdomainrequest.min.js');
 app.import(app.bowerDirectory + '/js-cookie/src/js.cookie.js');
-app.import(app.bowerDirectory + '/jQuery.dotdotdot/src/js/jquery.dotdotdot.min.js');
+app.import(app.bowerDirectory + '/jQuery.dotdotdot/src/jquery.dotdotdot.min.js');
 
 module.exports = app.toTree();

--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "gmaps-for-apps": "~0.5.9",
     "auth0-lock": "~7.7.1",
     "jsrsasign": "~4.8.3",
-    "jQuery.dotdotdot": "^1.7.4",
+    "jQuery.dotdotdot": "^1.8.1",
     "showdown": "~1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The latest version (from 1.7.4 to 1.8.1) of dotdotdot has a breaking change when referencing the js file from the package folder, which is preventing ember from compiling.
