### PR TITLE
Add single-line button option

### DIFF
--- a/app/styles/cpn/_cpn-button.scss
+++ b/app/styles/cpn/_cpn-button.scss
@@ -212,3 +212,9 @@
 %cpn-button-full {
     width: 100%;
 }
+
+[cpn-button~="single-line"] {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}


### PR DESCRIPTION
Add an option to buttons where the text won't wrap onto another line but instead will be clipped by ellipsis.
