### PR TITLE
PR to add Ember Truth Helpers addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "auth0-ember-simple-auth": "1.0.4",
+    "bid-leeds": "latest",
     "broccoli-asset-rev": "^2.1.1",
     "broccoli-sass": "0.6.6",
     "connect-restreamer": "^1.0.2",
@@ -46,6 +47,7 @@
     "ember-radio-buttons": "4.0.1",
     "ember-resize": "0.0.10",
     "ember-select-2": "1.3.0",
+    "ember-truth-helpers": "1.2.0",
     "eslint": "^2.4.0",
     "eslint-config-airbnb": "^6.1.0",
     "express": "^4.13.3",
@@ -60,8 +62,7 @@
     "load-grunt-tasks": "^3.2.0",
     "morgan": "^1.6.1",
     "node-sass": "^3.2.0",
-    "rimraf": "2.4.2",
-    "bid-leeds": "latest"
+    "rimraf": "2.4.2"
   },
   "dependencies": {
     "ember-cli-simple-auth": "^0.8.0",


### PR DESCRIPTION
This will be used initially in the BID add-on's phone edit component but could be useful
See [Ember Truth Helpers](https://github.com/jmurphyau/ember-truth-helpers) for more details
