### PR TITLE
Enable browser zoom of Solomon

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6,7 +6,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>Solomon</title>
         <meta name="description" content="">
-        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0">{{content-for 'head'}}
+        <meta name="viewport" content="width=device-width, initial-scale=1">{{content-for 'head'}}
         <link rel="stylesheet" href="assets/vendor.css">
         <link rel="stylesheet" href="assets/hebe-dash.css">{{content-for 'head-footer'}}</head>
     


### PR DESCRIPTION
Zooming of Solomon is currently disabled with `user-scalable=0`, but it's come up multiple times in user testing that zooming is needed.
