### PR TITLE
Starting PR to remove padding from carousel list.

### DIFF
--- a/app/styles/cpn/_cpn-story.scss
+++ b/app/styles/cpn/_cpn-story.scss
@@ -372,6 +372,7 @@
                 
                         [cpn-story_carousel-list] {
                             height: 100% !important; // overrides inline style
+                            padding: 0;
                         }
                     
                             [cpn-story_carousel-item] {


### PR DESCRIPTION
Adding padding to ordered and unordered lists has affected the layout of story carousels. Will remove this padding from the carousel list.
