### PR TITLE
Modify list spacing

### DIFF
--- a/app/styles/base/_styleguide.scss
+++ b/app/styles/base/_styleguide.scss
@@ -96,14 +96,15 @@ a {
 ul, ol {
     padding-left: rem($spacing-base);
     
-    & & {
-        padding-top: rem($spacing-base / 2);
-    }
-    
     li {
         list-style-position: inside;
         list-style-type: disc;
         margin-bottom: rem($spacing-base / 2);
+        
+        > ul, > ol {
+            padding-top: rem($spacing-base / 2);
+            margin-bottom: rem($spacing-base / 2);
+        }
     }
 }
 


### PR DESCRIPTION
Nested lists have top padding to nudge them down from the list item above. But this applies to all nested lists, not just first descendants of list items. So something really far down in the DOM could get this top padding which throws the spacing off. This issue has highlighted that some of the markup probably needs to change, as there's some places where divs would be more appropriate than lists. Still, will make the application of the top padding scoped better.
