### PR TITLE
PR to allow goto routes from header sub nav items

### DIFF
--- a/app/components/gallery-nav-icon/component.js
+++ b/app/components/gallery-nav-icon/component.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-    click: function() {
-        this.sendAction('action',this.get('route'));
-    }
+  click() {
+    this.sendAction('action', this.get('route'));
+  },
 });

--- a/app/components/top-drawer-icon/component.js
+++ b/app/components/top-drawer-icon/component.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-		click: function() {
-			this.sendAction('action');
-		}
+  click() {
+    this.sendAction('action', this.get('route'));
+  },
 });

--- a/app/styles/patterns/_navigation.scss
+++ b/app/styles/patterns/_navigation.scss
@@ -181,8 +181,8 @@
 
 	/* Top drawer nav */
 	&.-top-drawer {
-
-	}
+    padding-left: 0px;
+  }
 }
 
 .nav-main__title {


### PR DESCRIPTION
Currently a router's navItems can have a `gotoRoute` action with a `route` value ([see here](https://github.com/hebeworks/Solomon/blob/develop/app/canvas/controller.js#L12)). When rendered this lets a user click the icon and transition to the route.

Currently the `gotoRoute` functionality is not implemented in subNavItems ([e.g. see here](https://github.com/hebeworks/Solomon/blob/develop/app/canvas/controller.js#L29))
