### PR TITLE
Fix Frame transitions

### DIFF
--- a/app/styles/components/_drawer.scss
+++ b/app/styles/components/_drawer.scss
@@ -4,7 +4,8 @@
 		color: #fff;
 	}
 	position: absolute;
-	@include transition(transform .3s ease-in-out);
+	@include transition-property(transform);
+	@include transition-duration(.3s);
 
 	&.-top {
 		height: 100px;


### PR DESCRIPTION
Currently can't use mixins with multiple options passed in (see #66), meaning the Bottom Drawer and Toolbox don't animate when open. Will be expanding the shorthand mixins in this PR so each mixin is only passed a single option.
