### PR TITLE
Bump node-sass back to latest stable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "liquid-fire": "0.21.2",
     "load-grunt-tasks": "^3.2.0",
     "morgan": "^1.6.1",
-    "node-sass": "3.3.3",
+    "node-sass": "^3.4.2",
     "rimraf": "2.4.2",
     "strip-ansi": "^3.0.1"
   },


### PR DESCRIPTION
Downgrading node-sass to 3.3.3 hasn't resolved the issue in #66, so we're using longhand mixins instead of the shorthand ones with multiple options passed in (see #92). As such we can upgrade node-sass back to the latest stable version.
