### PR TITLE
Story name attribute not being applied in IE10

### DIFF
--- a/app/components/stories/story-types/default-story/component.js
+++ b/app/components/stories/story-types/default-story/component.js
@@ -13,14 +13,9 @@ export default Ember.Component.extend(dashComponentBase, {
     }.on('init'),
 
     appendComponentNameClass: function () {
-        if (Ember.isEmpty(this.__proto__)) { // delayed check because this.__proto__ is initially undefined in IE
-            var _this = this;
-            setTimeout(_this.appendComponentNameClass, 200);
-        } else {
-            var dasherizedStoryName = s.strRightBack(this.__proto__._debugContainerKey, "/");
-            this.set('solomon-story', dasherizedStoryName);
-            this.attributeBindings.push('solomon-story');
-        }
+        const dasherizedStoryName = s.strRightBack(Object.getPrototypeOf(this)._debugContainerKey, "/");
+        this.set('solomon-story', dasherizedStoryName);
+        this.attributeBindings.push('solomon-story');
     }
 });
 


### PR DESCRIPTION
The attribute containing the Story name isn't being applied to the component in IE10 as it's using `__proto__` which isn't supported by <=IE10.
