### PR TITLE
Fix missing placeholder selectors

### DIFF
--- a/app/styles/components/stories/_compare-water-quality.scss
+++ b/app/styles/components/stories/_compare-water-quality.scss
@@ -1,6 +1,6 @@
 [spc-cwq] {
 	input {
-		@extend %cpn-input-ghost-light;
+		// @extend %cpn-input-ghost-light; // selector to extend does not exist
 		height: rem(35px);
 		font-size: rem(12px);
 	}

--- a/app/styles/components/stories/_river-levels.scss
+++ b/app/styles/components/stories/_river-levels.scss
@@ -23,7 +23,7 @@
 		}
 	}
 	.info-label {
-		//@extend %delta;
+		//@extend %delta; // selector to extend does not exist
 		border: 0;
 		border-radius: 4px;
 		display: block;

--- a/app/styles/patterns/_buttons.scss
+++ b/app/styles/patterns/_buttons.scss
@@ -1,5 +1,5 @@
 .btn {
-    @extend %delta;
+    // @extend %delta; // selector to extend does not exist
     border: 0;
     border-radius: 3px;
     cursor: pointer;

--- a/app/styles/patterns/_lists.scss
+++ b/app/styles/patterns/_lists.scss
@@ -20,7 +20,7 @@
 		}
 		
 		&-item {
-			@extend .dashed-area.bottom;
+			// @extend .dashed-area.bottom; // selector to extend does not exist
 			
 			&.-full-width {
 				width:100%;

--- a/app/styles/vendor/doorbell/_doorbell.scss
+++ b/app/styles/vendor/doorbell/_doorbell.scss
@@ -23,7 +23,7 @@
         }
         
         textarea {
-            @extend %textarea;
+            // @extend %textarea; // selector to extend does not exist
             box-sizing: border-box;
             width: 100%;
         }
@@ -34,7 +34,7 @@
             }
             
             &[type="email"] {
-                @extend %input-text;
+                // @extend %input-text; // selector to extend does not exist
                 box-sizing: border-box;
             }
         }


### PR DESCRIPTION
Since the bump to [3.3.3 Delorean](https://github.com/sass/libsass/releases/tag/3.3.3), LibSass now correctly throws an error on an `@extends` which extends a placeholder selector that cannot be found (see https://github.com/sass/libsass/issues/1670). As such there are numerous instances of missing placeholder selectors being extended, so we'll deal with those in this PR.
