### PR TITLE
Add custom styling to native select elements

### DIFF
--- a/app/styleguide/template.hbs
+++ b/app/styleguide/template.hbs
@@ -307,6 +307,15 @@
             </div>
             
             <div cpn-margin="bottom-double">
+                <label cpn-label="above" for="">Native Select - Single</label>
+                <select name="" id="">
+                    <option value="">Option 1</option>
+                    <option value="">Option 2</option>
+                    <option value="">Option 3</option>
+                </select>
+            </div>
+            
+            <div cpn-margin="bottom-double">
                 <label cpn-label="above" for="">Radio Buttons</label>
                 <ul cpn-row-list="middle">
                     <li>

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -13,12 +13,13 @@
 @import "helpers/functions";
 @import "helpers/mixins";
 
+@import "patterns/svg-datauri";
+
 // ===== Base ===== //
 // @import "base/reset";
 @import "base/styleguide";
 
 // ===== Patterns (these are being replaced by CPN) ===== //
-@import "patterns/svg-datauri";
 @import "patterns/custom_fonts";
 @import "patterns/headings";
 @import "patterns/typography";

--- a/app/styles/base/_styleguide.scss
+++ b/app/styles/base/_styleguide.scss
@@ -153,6 +153,79 @@ img {
     max-width: 100%;
 }
 
+select {
+    $input-height: 40px;
+    $input-border-width: 2px;
+    
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    height: rem($input-height);
+    padding: rem(7px) rem(39px) rem(7px) rem(($spacing-base * 1.5) - $input-border-width);
+    border: rem($input-border-width) solid $light-grey;
+    color: $color-app-black;
+    background-color: #fff;
+    font-size: rem($font-base);
+    line-height: rem(22px);
+    border-radius: rem(3px);
+    outline: none;
+    box-shadow: none;
+    @include appearance(none);
+    @include svg--chevron-down;
+    background-size: rem(12.5px) rem(7px);
+    background-position: right rem($spacing-base * 1.5) center;
+    
+    &:focus {
+        outline: none;
+        border-color: $grey;
+    }
+    
+    &:disabled {
+        cursor: not-allowed;
+        background-color: $light-grey;
+        color: $grey;
+        
+        &::-ms-value {
+            background-color: $light-grey;
+            color: $grey;
+        }
+    }
+    
+    &::-webkit-input-placeholder {
+       color: $grey;
+    }
+
+    &::-moz-placeholder {
+       color: $grey;  
+    }
+
+    &:-ms-input-placeholder {  
+       color: $grey;  
+    }
+    
+    &:invalid {
+        border-color: $color-app-error;
+        background-color: lighten($color-app-error, 40%);
+    }
+    
+    // Removes the default arrow in IE
+    &::-ms-expand {
+        display: none;
+    }
+    
+    // Removes the blue background in IE
+    &::-ms-value {
+        background-color: #fff;
+        color: $color-app-black;
+    }
+    
+    // Removes the dotted border in Firefox
+    &:-moz-focusring {
+        color: transparent;
+        text-shadow: 0 0 0 $color-app-black;
+    }
+}
+
 /* -- Wrapper for Dashboard slide */
 .wrapper {
     width: 100%;


### PR DESCRIPTION
Due to issues with the Select2 component, where possible, we want to use the native `select` element, but the styling needs bringing inline with the rest of Solomon's form styles.
