### PR TITLE
PR to fix requests to York's datastore

### DIFF
--- a/app/components/stories/complete/york/demographic-kpis/component.js
+++ b/app/components/stories/complete/york/demographic-kpis/component.js
@@ -126,25 +126,26 @@ export default BaseRAGTile.extend(EditableFields, {
         }
     ],
     shortText: 'Edit the story to choose a KPI to display',
-    
+
     onInsertElement: function() {
         this.getData();
     }.on('didInsertElement'),
-    
+
     getData: function() {
         var _this = this;
         var data = {
             resource_id: '04d56453-f3a5-4f19-94e0-ea1d9ddd6838', // dataset ID
         };
-        
+
         $.ajax({
             url: 'https://data.yorkopendata.org/api/action/datastore_search',
             data: data,
+            cache: true,
             dataType: 'jsonp',
             success: function(data) {
                 var fullKpis = data.result.records; // Get out the actual full data
                 var strippedKpis = [];
-                
+
                 // Remove data objects we don't need
                 fullKpis.forEach(function(item) {
                     if (item.Total != '-' && item.Total != 'N/A' && item.Total != 'NC') {
@@ -157,24 +158,24 @@ export default BaseRAGTile.extend(EditableFields, {
                         });
                     }
                 });
-                
+
                 // Group KPI records by KPI ID
                 var groupedKpis = _.groupBy(strippedKpis, function(item) {
                     return item.id;
                 });
-                
+
                 var finalKpis = {};
-                
+
                 // Use this grouped list and create singular KPI objects with exactly what we need
                 for(var id in groupedKpis) {
                     var items = groupedKpis[id];
-                    
+
                     // Use the second year of the period so we can find the previous period data
                     items = _.sortBy(items,function(obj){
                         return parseInt(obj.period.substr(obj.period.indexOf('/') + 1));
                     });
                     items.reverse();
-                    
+
                     var firstItem = items[0];
 
                     finalKpis[id] = {
@@ -183,38 +184,38 @@ export default BaseRAGTile.extend(EditableFields, {
                         currentVal: firstItem.value,
                         currentPeriod: firstItem.period
                     }
-                    
+
                     if(items.length > 1) {
                         finalKpis[id].previousVal = items[1].value;
                         finalKpis[id].previousPeriod = items[1].period;
                     }
-                    
+
                     // This KPI has percentages listed as floats, so lets put '%' back on
                     if (id == 'PHOF15') {
                         finalKpis[id].currentVal = parseInt(firstItem.value) + '%';
                         finalKpis[id].previousVal = parseInt(items[1].value) + '%';
                     }
                 }
-                
+
                 _this.set('usableKpis', finalKpis);
-                
+
                 setTimeout(function () {
                     _this.set('loaded', true);
                 });
             }
         });
     },
-    
+
     showKpi: function() {
         var _this = this,
             kpis = _this.usableKpis;
-        
+
         for (var id in kpis) {
             if (id == _this.chosenKpi) {
                 _this.set('currentValue', kpis[id]['currentVal']);
                 _this.set('previousValue', kpis[id]['previousVal']);
                 _this.set('previousPeriod', kpis[id]['previousPeriod']);
-                
+
                 _this.displayableKpis.forEach(function(item) {
                     if (item.id == id) {
                         if (item.short == true) {
@@ -226,38 +227,38 @@ export default BaseRAGTile.extend(EditableFields, {
                         }
                     }
                 });
-                
+
                 var polarity = kpis[id]['polarity'],
                     previousFloat = parseFloat(kpis[id]['previousVal']),
                     currentFloat = parseFloat(kpis[id]['currentVal']);
-                    
+
                 if (currentFloat > previousFloat) {
                     _this.set('trend', 'up');
                     Ember.run.scheduleOnce('afterRender', this, grunticon.embedSVG);
-                    
+
                     if (polarity === 'Up is Good') {
                         _this.set('rating', 'good');
                     }
-                    
+
                     if (polarity === 'Up is Bad') {
                         _this.set('rating', 'bad');
                     }
-                    
+
                     if (polarity === 'Neutral') {
                         _this.set('rating', 'neutral');
                     }
                 } else if (currentFloat < previousFloat) {
                     _this.set('trend', 'down');
                     Ember.run.scheduleOnce('afterRender', this, grunticon.embedSVG);
-                    
+
                     if (polarity === 'Up is Good') {
                         _this.set('rating', 'bad');
                     }
-                    
+
                     if (polarity === 'Up is Bad') {
                         _this.set('rating', 'good');
                     }
-                    
+
                     if (polarity === 'Neutral') {
                         _this.set('rating', 'neutral');
                     }
@@ -267,12 +268,12 @@ export default BaseRAGTile.extend(EditableFields, {
             }
         }
     }.observes('loaded', 'chosenKpi'),
-    
+
     editableFields: function(){
         var _this = this;
         var selectableKpis = this.get('selectableKpis');
         var chosenKpi = this.get('chosenKpi');
-        
+
         return [
             {
                 name: 'displayed_kpi',
@@ -283,7 +284,7 @@ export default BaseRAGTile.extend(EditableFields, {
             }
         ];
     }.property('storyModel.config'),
-    
+
     onKpiChanged: function () {
         var kpi = this.fetchEditableFieldValue('displayed_kpi');
         if (!Ember.isEmpty(kpi)) {

--- a/app/components/stories/complete/york/ksi-kpis/component.js
+++ b/app/components/stories/complete/york/ksi-kpis/component.js
@@ -4,21 +4,22 @@ export default BaseRAGTile.extend({
     onInsertElement: function() {
         this.getData();
     }.on('didInsertElement'),
-    
+
     getData: function() {
         var _this = this;
         var data = {
             resource_id: '6a4ee483-0563-4971-9988-ffd34ba2b9da', // dataset ID
         };
-        
+
         $.ajax({
             url: 'https://data.yorkopendata.org/api/action/datastore_search',
             data: data,
             dataType: 'jsonp',
+            cache: true,
             success: function(data) {
                 var fullKsis = data.result.records,
                     strippedKsis = [];
-                    
+
                 fullKsis.forEach(function(item) {
                     // We only want year values, so strip out any records with monthly or quarterly values
                     if (item.Period.length < 10) {
@@ -28,19 +29,19 @@ export default BaseRAGTile.extend({
                         });
                     }
                 });
-                
+
                 strippedKsis = _.sortBy(strippedKsis, function(obj) {
                     return parseInt(obj.period.substring(obj.period.indexOf('/') + 1));
                 });
                 strippedKsis.reverse();
-                
+
                 var current = strippedKsis[0],
                     previous = strippedKsis[1];
-                
+
                 _this.set('currentValue', current.value);
                 _this.set('previousValue', previous.value);
                 _this.set('previousPeriod', previous.period);
-                
+
                 if (current.value < previous.value) {
                     _this.set('rating', 'good');
                     _this.set('trend', 'down');
@@ -50,7 +51,7 @@ export default BaseRAGTile.extend({
                 } else {
                     _this.set('rating', 'neutral');
                 }
-                
+
                 _this.set('longText', 'people reported killed or seriously injured in road traffic accidents in ' + current.period);
             }
         });

--- a/app/components/stories/complete/york/library-locations/component.js
+++ b/app/components/stories/complete/york/library-locations/component.js
@@ -16,17 +16,17 @@ export default DefaultStory.extend({
         showHeaderBorder: false,
         showLoading: true
     },
-    
+
     loaded: false, // (Tell other elements that this story has loaded)
     libraries: null,
     mapData: null,
-    
+
     // Map properties
     lat: 53.9801797,
     lng: -1.0750533,
     zoom: 11,
     markers: Ember.A(),
-    
+
     onInsertElement: function () {
         this.getData();
     }.on('didInsertElement'),
@@ -36,24 +36,25 @@ export default DefaultStory.extend({
         var data = {
             resource_id: 'ff914244-101c-4ff5-b4ac-cb7b0c0795c1'
         };
-        
+
         $.ajax({
             url: 'https://data.yorkopendata.org/api/action/datastore_search',
             data: data,
+            cache: true,
             dataType: 'jsonp',
             success: function(data) {
                 // console.log('Full Libraries');
                 // console.log('==============');
                 // console.log(data.result.records);
                 // console.log('==============');
-                
+
                 var fullLibraries = data.result.records,
                     libraryCount = data.result.records.length,
                     strippedLibraries = [],
                     mappedLibraries = [];
 
                 // "﻿X" - The 'X' property has an erroneous character in it's name. The double-quoted X has this character included.
-                
+
                 fullLibraries.forEach(function(library) {
                     strippedLibraries.push({
                         id: library._id,
@@ -64,27 +65,27 @@ export default DefaultStory.extend({
                         email: library.EMAIL,
                         phone: library.PHONE
                     });
-                    
+
                     var infoWindowContent = '<div><p><strong>' + library.NAME + '</strong></p><p><em>' + library.TYPE + '</em></p><p>' + library.ADDRESS + '</p>';
-                    
+
                     if ((library.PHONE != 'n/a' && library.PHONE != ' ') || (library.EMAIL != 'n/a' && library.EMAIL != ' ')) {
                         infoWindowContent += '<ul>';
-                        
+
                         if (library.PHONE != 'n/a' && library.PHONE != ' ') {
                             infoWindowContent += '<li>' + library.PHONE + '</li>';
                         }
-                        
+
                         if (library.EMAIL != 'n/a' && library.EMAIL != ' ') {
                             infoWindowContent += '<li><a href="mailto:' + library.EMAIL + '">Email</a></li>';
                         }
-                        
+
                         infoWindowContent += '<li><a target="_blank" href="' + library.WEBSITE + '">Website</a></li></ul>';
                     } else {
                         infoWindowContent += '<ul><li><a target="_blank" href="' + library.WEBSITE + '">Website</a></li></ul>';
                     }
-                    
+
                     infoWindowContent += '</div>';
-                    
+
                     mappedLibraries.push({
                         id: library._id,
                         title: library.NAME,
@@ -93,16 +94,16 @@ export default DefaultStory.extend({
                         infoWindow: { content: infoWindowContent }
                     });
                 });
-                
+
                 // console.log('Stripped Libraries');
                 // console.log('==============');
                 // console.log(strippedLibraries);
                 // console.log('==============');
-                
+
                 _this.set('libraries', strippedLibraries);
                 _this.markers.pushObjects(mappedLibraries);
                 _this.set('mapData', mappedLibraries);
-                
+
                 setTimeout(function () {
                     _this.set('loaded', true);
                 });

--- a/config/environment.js
+++ b/config/environment.js
@@ -100,9 +100,11 @@ module.exports = function config(environment) {
     // lets you simulate a particular site e.g. 'leeds.preview.mysolomon.co.uk' core etc
     // ENV.APP.mockSolomonHostname = 'leeds.preview.mysolomon.co.uk'; 'bid.preview.mysolomon.co.uk';
     // ENV.APP.solomonClientOverride = 'solomon_production';
-    ENV.APP.mockSolomonHostname = 'aware.mysolomon.co.uk'; //'leeds.preview.mysolomon.co.uk';
-    // ENV.APP.solomonClientOverride = 'solomon_bid_leeds'; // solomon_production solomon_leeds
-    ENV['auth0-ember-simple-auth'] = auth0Configs.development;
+    // ENV.APP.mockSolomonHostname = 'aware.mysolomon.co.uk'; //'leeds.preview.mysolomon.co.uk';
+    // ENV['auth0-ember-simple-auth'] = auth0Configs.development;
+    ENV.APP.mockSolomonHostname = 'york.mysolomon.co.uk';
+    ENV.APP.solomonClientOverride = 'solomon_york'; // solomon_production solomon_leeds
+    ENV['auth0-ember-simple-auth'] = auth0Configs.production;
     ENV.APP.solomonAPIURL = 'http://testing.api.mysolomon.co.uk';
     // ENV.APP.solomonAPIURL = 'http://localhost:3000';
   }

--- a/config/environment.js
+++ b/config/environment.js
@@ -123,6 +123,7 @@ module.exports = function config(environment) {
 
   if (environment === 'production') {
     // ENV['auth0-ember-simple-auth'] = auth0Configs.bid;
+    ENV['auth0-ember-simple-auth'] = auth0Configs.production;
     ENV.APP.solomonAPIURL = 'http://testing.api.mysolomon.co.uk';
   }
 


### PR DESCRIPTION
York has started getting errors like

```
https://data.yorkopendata.org/api/action/datastore_search?callback=jQuery21406677047193516046_1464277932118&resource_id=04d56453-f3a5-4f19-94e0-ea1d9ddd6838&_=1464277932119
Failed to load resource: the server responded with a status of 409 (Conflict)
```

`&_=1464277932119`
is the additional cache param

I believe this is due to the Ajax request adding a cache-busting query string so will use Solomon's default getData to not send the cache param
